### PR TITLE
Mistaking IOError with OSError in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ password = getpass()
 
 try:
     rskeyring.set_password("service", username, password)
-except IOError:
+except OSError:
     print(f"Unable to create or update service for {username}."
         f"\nPlease make sure you have the proper permissions")
 ```

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.1.1",
     author="David Krasnitsky",
     author_email="dikaveman@gmail.com",
-    description="A C-level keyring module ported from the Rust programming language (crates.io)",
+    description="A C-level keyring module bind from the Rust programming language (crates.io)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/DK26/pyrust-keyring",


### PR DESCRIPTION
Mistake in README.md documentation, showing example with `IOError `when it supposed to be `OSError`.