### PR TITLE
0.1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.1.2.2
+- Fixed version in `Cargo.toml` from `0.1.2.1` to `0.1.2` as Cargo doesn't support the previous format.
+
 ## Version 0.1.2.1
 - Fixed a mistake in implementing the `setuptools_rust` & created the `pyproject.toml` file.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rskeyring"
-version = "0.1.2.1"
+version = "0.1.2"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 edition = "2018"
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="rskeyring",
-    version="0.1.2.1",
+    version="0.1.2.2",
     author="David Krasnitsky",
     author_email="dikaveman@gmail.com",
     description="A C-level keyring module bind from the Rust programming language (crates.io)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ py_module_initializer!(rskeyring, |py, m | {
 
             GitHub:     https://github.com/DK26
 
-        Version: 0.1.2.1"#;
+        Version: 0.1.2.2"#;
 
     m.add(py, "__doc__", doc)?;
     m.add(py, "set_password", py_fn!(py, set_password(service: &str, username: &str, password: &str)))?;


### PR DESCRIPTION
## Version 0.1.2.2
- Fixed version in `Cargo.toml` from `0.1.2.1` to `0.1.2` as Cargo doesn't support the previous format.
